### PR TITLE
Show time strings for the local timezone in alert messages.

### DIFF
--- a/meerkat_abacus/config.py
+++ b/meerkat_abacus/config.py
@@ -89,6 +89,9 @@ class Config:
         if self.hermes_dev:
             self.country_config["messaging_silent"] = True
 
+        if not self.country_config.get("timezone"):
+            self.country_config["timezone"] = "Europe/Dublin"
+
         self.s3_bucket = country_config_module.s3_bucket
 
         # Configure data initialisation

--- a/meerkat_abacus/config.py
+++ b/meerkat_abacus/config.py
@@ -40,7 +40,6 @@ class Config:
                                         current_directory + "/data/")
         self.config_directory = os.environ.get("COUNTRY_CONFIG_DIR",
                                           current_directory + "/country_config/")
-        self.timezone = os.environ.get('TIMEZONE', 'Europe/Dublin')
 
         self.start_celery = os.environ.get("START_CELERY", False)
 

--- a/meerkat_abacus/data_management.py
+++ b/meerkat_abacus/data_management.py
@@ -410,8 +410,8 @@ def import_geojson(geo_json, session):
             name = g["properties"]["Name"]
             location = session.query(model.Locations).filter(
                 model.Locations.name == name,
-                model.Locations.level.in_(["district",
-                                           "region", "country"])).first()
+                model.Locations.level.in_(["district", "region", "country"])
+            ).first()
             if location is not None:
                 location.area = from_shape(shapely_shapes)
             session.commit()

--- a/meerkat_abacus/orchestrate.py
+++ b/meerkat_abacus/orchestrate.py
@@ -45,7 +45,7 @@ logging.info("Setting up DB for %s", config.country_config["country_name"])
 global engine
 global session
 
-tz = pytz.timezone(config.timezone)
+tz = pytz.timezone(config.country_config.get("timezone", "Europe/Dublin"))
 
 param_config_yaml = yaml.dump(config)
 
@@ -78,6 +78,6 @@ if config.fake_data:
                                             "internal_fake_data": copy.deepcopy(config.internal_fake_data),
                                             "param_config_yaml": param_config_yaml
                                             })
-              
+
 while True:
     sleep(120)

--- a/meerkat_abacus/orchestrate.py
+++ b/meerkat_abacus/orchestrate.py
@@ -45,7 +45,7 @@ logging.info("Setting up DB for %s", config.country_config["country_name"])
 global engine
 global session
 
-tz = pytz.timezone(config.country_config.get("timezone", "Europe/Dublin"))
+tz = pytz.timezone(config.country_config["timezone"])
 
 param_config_yaml = yaml.dump(config)
 

--- a/meerkat_abacus/util/__init__.py
+++ b/meerkat_abacus/util/__init__.py
@@ -517,9 +517,7 @@ def send_alert(alert_id, alert, variables, locations, param_config=config):
         # To display date-times as a local date string.
         def tostr(date):
             try:
-                local_timezone = pytz.timezone(param_config.country_config.get(
-                    "timezone", "Europe/Dublin"
-                ))
+                local_timezone = pytz.timezone(param_config.country_config["timezone"])
                 utc_date = parse(date).replace(tzinfo=pytz.utc)
                 local_date = utc_date.astimezone(local_timezone)
                 return local_date.strftime("%H:%M %d %b %Y")


### PR DESCRIPTION
- Moved the timezone configuration to the country config 
- Assumed GMT timezone for dates in the alert object.
- More thought should be given to how we handle timezones - at the moment I think pretty much everything is naive GMT times.
- Converted the alert date/times into local time strings for use in alert message templates.
- Created a couple of assertions in the unit test to check that the timezone conversion happens properly. 

Addresses issue https://github.com/meerkat-code/meerkat_issues/issues/263